### PR TITLE
Made readme.md more clear and fixed bug in installer.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,22 @@ git clone https://github.com/ssilverm/piplay-installer
 cd piplay-installer
 ```
 
-## To Install On A Fresh SD Card
+## INSTALLING ON A NEW SD CARD
+
+Start by provisioning an SD-Card with the latest version of Raspbian. Once Raspbian is installed, insert it into the RPi and boot it up.
+
+From the RPi console, run the following: 
 
 ```sh
+sudo apt-get install git python-pygame
+mkdir ~/src
+cd ~/src
+git clone https://github.com/ssilverm/piplay-installer
+cd pipplay-installer
 bash installer.sh
 ```
 
-## To update an earlier version of PiPLAY
+## UPDATING TO A NEWER VERSION OF PIPLAY
 
 ```sh
 bash updater.sh

--- a/installer.sh
+++ b/installer.sh
@@ -5,7 +5,6 @@
 #fi
 
 echo "Starting Install..."
-d
 sudo apt-get clean
 sudo apt-get update
 sudo apt-get -y install vsftpd xboxdrv stella python-pip python-requests python-levenshtein libsdl1.2-dev bc gunicorn sqlite3

--- a/installer.sh
+++ b/installer.sh
@@ -5,7 +5,7 @@
 #fi
 
 echo "Starting Install..."
-
+d
 sudo apt-get clean
 sudo apt-get update
 sudo apt-get -y install vsftpd xboxdrv stella python-pip python-requests python-levenshtein libsdl1.2-dev bc gunicorn sqlite3
@@ -37,19 +37,14 @@ wget http://sheasilverman.com/rpi/raspbian/installer/vice_2.3.21-1_armhf.deb
 sudo dpkg -i vice_2.3.21-1_armhf.deb
 rm -rf vice_2.3.21-1_armhf.deb
 
-
-
-
-echo 'if [ "$DISPLAY" == "" ] && [ "$SSH_CLIENT" == "" ] && [ "$SSH_TTY" == "" ]; then' >> /home/pi/.profile
-
 if grep --quiet /home/pi/pimame/pimame-menu /home/pi/.profile; then
   echo "menu already exists, ignoring."
 else
-	echo 'cd /home/pi/pimame/pimame-menu/' >> /home/pi/.profile
-	echo 'python launchmenu.py' >> /home/pi/.profile
+  echo 'if [ "$DISPLAY" == "" ] && [ "$SSH_CLIENT" == "" ] && [ "$SSH_TTY" == "" ]; then' >> /home/pi/.profile
+  echo '  cd /home/pi/pimame/pimame-menu/' >> /home/pi/.profile
+  echo '  python launchmenu.py' >> /home/pi/.profile
+  echo 'fi' >> /home/pi/.profile
 fi
-
-echo 'fi' >> /home/pi/.profile
 
 sudo apt-get -y install supervisor
 sudo cp /home/pi/pimame/supervisor_scripts/file_watcher.conf /etc/supervisor/conf.d/file_watcher.conf


### PR DESCRIPTION
There was a bug in installer.sh that caused an empty "if / fi" to be added to the user .profile, which causes an error to occur at startup, if installer.sh is ran more than once.

I also clarified the readme.md and made mention of one missing dependency (python-pygame).  

Since most tools like this require you to image an SD card from a separate computer, I foolishly ran these original instructions from my Linux box, not from Raspbian.  The original wording mentions "With a FRESH SD CARD" which implies that it's new, blank, or formatted - NOT that it has Raspbian or another OS loaded already.  I should have checked the script first, but also the instructions should be clearer.
